### PR TITLE
Add sample names CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ both names quoted to ensure each is parsed correctly:
 python name_similarity.py compare "John Smith" "Johnny Smith"
 ```
 
+For a quick demonstration of how the scoring works, run the `samples`
+command to print scores for a collection of common name pairs:
+
+```bash
+python name_similarity.py samples
+```
+
 If either argument omits a first or last name, the command exits with an
 error message.
 

--- a/name_similarity.py
+++ b/name_similarity.py
@@ -14,6 +14,35 @@ nn = NickNamer()
 # default threshold for acceptable alias match
 THRESHOLD = 80
 
+# list of sample name pairs for the "samples" command
+SAMPLES = [
+    ("Robert Smith", "Bob Smith"),
+    ("William Johnson", "Bill Johnson"),
+    ("James Brown", "Jim Brown"),
+    ("John Wilson", "Jonathan Wilson"),
+    ("Margaret Taylor", "Maggie Taylor"),
+    ("Elizabeth Thomas", "Liz Thomas"),
+    ("Jennifer White", "Jen White"),
+    ("Christopher Harris", "Chris Harris"),
+    ("Patricia Martin", "Patty Martin"),
+    ("Charles Thompson", "Charlie Thompson"),
+    ("Michael Garcia", "Mike Garcia"),
+    ("Steven Martinez", "Steve Martinez"),
+    ("Barbara Robinson", "Barb Robinson"),
+    ("Richard Clark", "Rick Clark"),
+    ("Deborah Rodriguez", "Debby Rodriguez"),
+    ("Anthony Lewis", "Tony Lewis"),
+    ("Daniel Lee", "Dan Lee"),
+    ("Joseph Walker", "Joe Walker"),
+    ("Susan Hall", "Sue Hall"),
+    ("Andrew Allen", "Andy Allen"),
+    ("Matthew Young", "Matt Young"),
+    ("Alexander King", "Alex King"),
+    ("Nicholas Wright", "Nick Wright"),
+    ("Benjamin Scott", "Ben Scott"),
+    ("Joshua Green", "Josh Green"),
+]
+
 def compute_score(name1: str, name2: str) -> tuple[int, int]:
     """Compute the similarity between two names.
 
@@ -78,6 +107,10 @@ def main():
     compare_parser.add_argument("name1", help="First full name in quotes")
     compare_parser.add_argument("name2", help="Second full name in quotes")
 
+    subparsers.add_parser(
+        "samples", help="Display scores for a list of sample name pairs"
+    )
+
     args = parser.parse_args()
 
     if args.command == "compare":
@@ -99,6 +132,10 @@ def main():
             print("Alias is an acceptable match based on first name.")
         else:
             print("Alias first name too different; manual verification needed.")
+    elif args.command == "samples":
+        for name1, name2 in SAMPLES:
+            first_score, last_score = compute_score(name1, name2)
+            print(f"{name1} vs {name2} -> first: {first_score}, last: {last_score}")
 
 
 if __name__ == "__main__":

--- a/tests/test_name_similarity.py
+++ b/tests/test_name_similarity.py
@@ -35,3 +35,15 @@ def test_cli_requires_full_names():
     )
     assert result.returncode != 0
     assert "Both names must include first and last name" in result.stderr
+
+
+def test_sample_command_outputs_pairs():
+    script = ROOT / "name_similarity.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "samples"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert len(lines) >= 25


### PR DESCRIPTION
## Summary
- add `samples` CLI command to display preset name comparisons
- show sample usage in README
- test the new `samples` command

## Testing
- `pytest -q`
- `python name_similarity.py samples | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_68829473ec008321b42bbadff55175cc