### PR TITLE
Handle multi-part surnames in compute_score

### DIFF
--- a/tests/test_name_similarity.py
+++ b/tests/test_name_similarity.py
@@ -26,6 +26,18 @@ def test_dissimilar_names_below_threshold():
     assert last < THRESHOLD
 
 
+def test_middle_name_handling():
+    first, last = compute_score("John Paul Jones", "John Jones")
+    assert first == 100
+    assert last == 100
+
+
+def test_compound_last_name():
+    first, last = compute_score("Gabriel Garcia Marquez", "Gabriel Marquez")
+    assert first == 100
+    assert last == 100
+
+
 def test_cli_requires_full_names():
     script = ROOT / "name_similarity.py"
     result = subprocess.run(


### PR DESCRIPTION
## Summary
- support multi-part last names in `compute_score`
- support optional middle-name ignoring behavior
- update `_print_comparison` accordingly
- test names that include middle names and compound surnames
- add examples with middle names or compound surnames to sample pairs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883adade624832188fbaff901ba3911